### PR TITLE
Remove ts-loader dependency

### DIFF
--- a/src/lib/application/files/ts/package.json
+++ b/src/lib/application/files/ts/package.json
@@ -43,7 +43,6 @@
     "source-map-support": "^0.5.20",
     "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
-    "ts-loader": "^9.2.3",
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5"


### PR DESCRIPTION
ts-loader is a frontend webpack loader and not required in NestJS.

This removes the dependency from the application schematic.